### PR TITLE
Handle more JuMP containers on NLS

### DIFF
--- a/test/test_moi_nls_model.jl
+++ b/test/test_moi_nls_model.jl
@@ -18,3 +18,51 @@ for prob in [:mgh01, :mgh07, :lls, :hs30, :hs43, :nlshs20]
   @printf("%-15s  %4d  %4d  %4d  %10.4e  %10.4e  %10s\n", prob, N, n, m, nFx, JtF, ncx)
 end
 println()
+
+println("Testing 2d cat array on NLS")
+model = Model()
+@variable(model, x[1:2])
+@NLexpression(model, F[i=1:2], x[i] - 1)
+@NLexpression(model, G[i=1:2], x[i]^2 - 1)
+@NLexpression(model, H[i=1:2, j=1:2], x[i] * x[j] - 1)
+@test F isa Array{NonlinearExpression}
+@test G isa Array{NonlinearExpression}
+@test H isa Array{NonlinearExpression}
+@test [[F G]; H] isa Array{NonlinearExpression}
+nls = MathOptNLSModel(model, [[F G]; H])
+@test all(residual(nls, ones(2)) .== 0.0)
+@test jac_residual(nls, ones(2))' * residual(nls, ones(2)) == [0.0; 0.0]
+
+println("Testing Dense JuMP container on NLS")
+model = Model()
+@variable(model, x[1:2])
+@NLexpression(model, F[i=-1:1,j=1:2], x[j] - i)
+@test F isa JuMP.Containers.DenseAxisArray
+nls = MathOptNLSModel(model, F)
+@test residual(nls, zeros(2)) == [1.0; 0.0; -1.0; 1.0; 0.0; -1.0]
+@test jac_residual(nls, zeros(2))' * residual(nls, zeros(2)) == [0.0; 0.0]
+
+println("Testing Sparse JuMP container on NLS")
+model = Model()
+@variable(model, x[1:2])
+D = Dict(1 => 2, 2 => 4)
+@NLexpression(model, F[i=1:2,j=1:D[i]], x[i] - j)
+@test F isa JuMP.Containers.SparseAxisArray
+nls = MathOptNLSModel(model, F)
+# Order is not preserved
+@test sort(residual(nls, [1.5; 2.5])) == [-1.5; -0.5; -0.5; 0.5; 0.5; 1.5]
+@test jac_residual(nls, [1.5; 2.5])' * residual(nls, [1.5; 2.5]) == [0.0; 0.0]
+
+println("Testing array of JuMP containers on NLS")
+model = Model()
+@variable(model, x[1:4])
+D = Dict(1 => 2, 2 => 4)
+@NLexpression(model, F[i=1:2,j=1:D[i]], x[i] - j)
+@NLexpression(model, G[i=-1:1,j=3:4], x[j] - i)
+@test F isa JuMP.Containers.SparseAxisArray
+@test G isa JuMP.Containers.DenseAxisArray
+@test [F,G] isa Array{<: AbstractArray{NonlinearExpression}}
+nls = MathOptNLSModel(model, [F, G])
+# Order is not preserved
+@test sort(residual(nls, [1.5; 2.5; 0.0; 0.0])) == [-1.5; -1.0; -1.0; -0.5; -0.5; 0.0; 0.0; 0.5; 0.5; 1.0; 1.0; 1.5]
+@test jac_residual(nls, [1.5; 2.5; 0.0; 0.0])' * residual(nls, [1.5; 2.5; 0.0; 0.0]) == [0.0; 0.0; 0.0; 0.0]


### PR DESCRIPTION
cf. @shoshievass

This expands the input of `MathOptNLSModel` to handle more generic containers than an array of nonlinear expressions.
~Doesn't handle arrays of containers yet.~