### PR TITLE
Fix a corner case in hprod! for quadratic objective

### DIFF
--- a/src/moi_nlp_model.jl
+++ b/src/moi_nlp_model.jl
@@ -226,6 +226,7 @@ function NLPModels.hprod!(nlp :: MathOptNLPModel, x :: AbstractVector, y :: Abst
     MOI.eval_hessian_lagrangian_product(nlp.eval, hv, x, v, obj_weight, view(y, nlp.meta.nln))
   end
   if nlp.obj.type == "QUADRATIC"
+    nlp.meta.nnln == 0 && (hv .= 0.0)
     for k = 1 : nlp.obj.nnzh
       i, j, c = nlp.obj.hessian.rows[k], nlp.obj.hessian.cols[k], nlp.obj.hessian.vals[k]
       hv[i] += obj_weight * c * v[j]


### PR DESCRIPTION
If a model has a quadratic objective without constaints or only linear constraints, the hessian of the lagrangian is only the hessian of the objective. We must do a `hv .= 0.0` to avoid some errors.

If the model has nonlinear constraints `hv .= 0.0` is done by the `MOI.eval_hessian_lagrangian_product` function that computes the hessian of the Lagrangian - vector product associated to the nonlinear constraints. Thereafter, if the objective is quadratic we add the hessian of the Lagrangian - vector product associated to the objective.