### PR TITLE
[WIP] Move tests to new JuMP nonlinear interface

### DIFF
--- a/test/nlp_problems/brownden.jl
+++ b/test/nlp_problems/brownden.jl
@@ -4,7 +4,7 @@ function brownden()
   @variable(nlp, x[1:4])
   set_start_value.(x, [25.0; 5.0; -5.0; -1.0])
 
-  @NLobjective(
+  @objective(
     nlp,
     Min,
     sum(

--- a/test/nlp_problems/hs100.jl
+++ b/test/nlp_problems/hs100.jl
@@ -3,12 +3,12 @@ function hs100(args...; kwargs...)
   x0 = [1, 2, 0, 4, 0, 1, 1]
   @variable(nlp, x[i = 1:7], start = x0[i])
 
-  @NLconstraint(nlp, 127 - 2 * x[1]^2 - 3 * x[2]^4 - x[3] - 4 * x[4]^2 - 5 * x[5] ≥ 0)
+  @constraint(nlp, 127 - 2 * x[1]^2 - 3 * x[2]^4 - x[3] - 4 * x[4]^2 - 5 * x[5] ≥ 0)
   @constraint(nlp, 282 - 7 * x[1] - 3 * x[2] - 10 * x[3]^2 - x[4] + x[5] ≥ 0)
   @constraint(nlp, -196 + 23 * x[1] + x[2]^2 + 6 * x[6]^2 - 8 * x[7] ≤ 0)
   @constraint(nlp, -4 * x[1]^2 - x[2]^2 + 3 * x[1] * x[2] - 2 * x[3]^2 - 5 * x[6] + 11 * x[7] ≥ 0)
 
-  @NLobjective(
+  @objective(
     nlp,
     Min,
     (x[1] - 10)^2 +
@@ -29,8 +29,8 @@ function hs100_oracle(args...; kwargs...)
   x0 = [1, 2, 0, 4, 0, 1, 1]
   @variable(model, x[i = 1:7], start = x0[i])
 
-  # 1st constraint: keep as NLconstraint
-  @NLconstraint(model, 127 - 2 * x[1]^2 - 3 * x[2]^4 - x[3] - 4 * x[4]^2 - 5 * x[5] ≥ 0)
+  # 1st constraint: keep as constraint
+  @constraint(model, 127 - 2 * x[1]^2 - 3 * x[2]^4 - x[3] - 4 * x[4]^2 - 5 * x[5] ≥ 0)
 
   # 2nd constraint as oracle:
   # Original: 282 - 7x1 - 3x2 - 10x3^2 - x4 + x5 ≥ 0
@@ -94,7 +94,7 @@ function hs100_oracle(args...; kwargs...)
   @constraint(model, -4 * x[1]^2 - x[2]^2 + 3 * x[1] * x[2] - 2 * x[3]^2 - 5 * x[6] + 11 * x[7] ≥ 0)
 
   # Objective: same as original
-  @NLobjective(
+  @objective(
     model,
     Min,
     (x[1] - 10)^2 +

--- a/test/nlp_problems/hs13.jl
+++ b/test/nlp_problems/hs13.jl
@@ -3,9 +3,9 @@ function hs13(args...; kwargs...)
   nlp = Model()
   @variable(nlp, x[i = 1:2] ≥ 0, start = -2)
 
-  @NLobjective(nlp, Min, (x[1] - 2)^2 + x[2]^2)
+  @objective(nlp, Min, (x[1] - 2)^2 + x[2]^2)
 
-  @NLconstraint(nlp, (1 - x[1])^3 ≥ x[2])
+  @constraint(nlp, (1 - x[1])^3 ≥ x[2])
 
   return nlp
 end

--- a/test/nlp_problems/hs219.jl
+++ b/test/nlp_problems/hs219.jl
@@ -4,9 +4,9 @@ function hs219(args...; kwargs...)
   @variable(nlp, x[i = 1:4], start = x0[i])
 
   @constraint(nlp, x[1]^2 - x[2] - x[4]^2 == 0)
-  @NLconstraint(nlp, x[2] - x[1]^3 - x[3]^2 == 0)
+  @constraint(nlp, x[2] - x[1]^3 - x[3]^2 == 0)
 
-  @NLobjective(nlp, Min, -x[1])
+  @objective(nlp, Min, -x[1])
 
   return nlp
 end

--- a/test/nlp_problems/hs5.jl
+++ b/test/nlp_problems/hs5.jl
@@ -6,7 +6,7 @@ function hs5()
   u = [4, 3]
   @variable(nlp, l[i] ≤ x[i = 1:2] ≤ u[i], start = 0.0)
 
-  @NLobjective(nlp, Min, sin(x[1] + x[2]) + (x[1] - x[2])^2 - 1.5 * x[1] + 2.5 * x[2] + 1)
+  @objective(nlp, Min, sin(x[1] + x[2]) + (x[1] - x[2])^2 - 1.5 * x[1] + 2.5 * x[2] + 1)
 
   return nlp
 end

--- a/test/nlp_problems/hs6.jl
+++ b/test/nlp_problems/hs6.jl
@@ -6,7 +6,7 @@ function hs6()
   set_start_value(x[1], -1.2)
   set_start_value(x[2], 1.0)
 
-  @NLobjective(nlp, Min, (1 - x[1])^2)
+  @objective(nlp, Min, (1 - x[1])^2)
 
   @constraint(nlp, 10 * (x[2] - x[1]^2) == 0)
 

--- a/test/nlp_problems/hs61.jl
+++ b/test/nlp_problems/hs61.jl
@@ -6,7 +6,7 @@ function hs61(args...; kwargs...)
   @constraint(nlp, 3 * x[1] - 2 * x[2]^2 - 7 == 0)
   @constraint(nlp, 4 * x[1] - x[3]^2 - 11 == 0)
 
-  @NLobjective(nlp, Min, 4 * x[1]^2 + 2 * x[2]^2 + 2 * x[3]^2 - 33 * x[1] + 16 * x[2] - 24 * x[3])
+  @objective(nlp, Min, 4 * x[1]^2 + 2 * x[2]^2 + 2 * x[3]^2 - 33 * x[1] + 16 * x[2] - 24 * x[3])
 
   return nlp
 end
@@ -16,7 +16,7 @@ function hs61_oracle(args...; kwargs...)
   model = Model()
   @variable(model, x[i = 1:3], start = 0)
 
-  @NLobjective(model, Min, 4 * x[1]^2 + 2 * x[2]^2 + 2 * x[3]^2 - 33 * x[1] + 16 * x[2] - 24 * x[3])
+  @objective(model, Min, 4 * x[1]^2 + 2 * x[2]^2 + 2 * x[3]^2 - 33 * x[1] + 16 * x[2] - 24 * x[3])
 
   # First equality: 3*x1 - 2*x2^2 - 7 == 0
   # Canonical form for MathOptNLPModel:

--- a/test/nlp_problems/lincon.jl
+++ b/test/nlp_problems/lincon.jl
@@ -23,7 +23,7 @@ function lincon()
 
   @constraint(nlp, 15.0 * x[15] - 21.0 == 1.0)
 
-  @NLobjective(nlp, Min, sum(i + x[i]^4 for i = 1:15))
+  @objective(nlp, Min, sum(i + x[i]^4 for i = 1:15))
 
   return nlp
 end

--- a/test/nlp_problems/nohesspb.jl
+++ b/test/nlp_problems/nohesspb.jl
@@ -11,8 +11,8 @@ function nohesspb()
     return v
   end
 
-  register(nlp, :g, 2, g, ∇g)
-  @NLobjective(nlp, Min, g(x[1], x[2]))
+  @operator(nlp, custom_g, 2, g, ∇g)
+  @objective(nlp, Min, custom_g(x[1], x[2]))
 
   return nlp
 end

--- a/test/nls_problems/hs30.jl
+++ b/test/nls_problems/hs30.jl
@@ -4,7 +4,7 @@ function hs30()
   lvar = [1.0; -10.0; -10.0]
   @variable(model, lvar[i] ≤ x[i = 1:3] ≤ 10, start = 1.0)
   @expression(model, F[i = 1:3], x[i])
-  @NLconstraint(model, x[1]^2 + x[2]^2 ≥ 1.0)
+  @constraint(model, x[1]^2 + x[2]^2 ≥ 1.0)
 
   return MathOptNLSModel(model, F, name = "hs30")
 end

--- a/test/nls_problems/hs43.jl
+++ b/test/nls_problems/hs43.jl
@@ -6,9 +6,9 @@ function hs43()
   @expression(model, F2, x[2] - 5 / 2)
   @expression(model, F3, sqrt(2) * (x[3] - 21 / 4))
   @expression(model, F4, x[4] + 7 / 2)
-  @NLconstraint(model, 8 - x[1]^2 - x[2]^2 - x[3]^2 - x[4]^2 - x[1] + x[2] - x[3] + x[4] ≥ 0.0)
-  @NLconstraint(model, 10 - x[1]^2 - 2 * x[2]^2 - x[3]^2 - 2 * x[4]^2 + x[1] + x[4] ≥ 0.0)
-  @NLconstraint(model, 5 - 2 * x[1]^2 - x[2]^2 - x[3]^2 - 2 * x[1] + x[2] + x[4] ≥ 0.0)
+  @constraint(model, 8 - x[1]^2 - x[2]^2 - x[3]^2 - x[4]^2 - x[1] + x[2] - x[3] + x[4] ≥ 0.0)
+  @constraint(model, 10 - x[1]^2 - 2 * x[2]^2 - x[3]^2 - 2 * x[4]^2 + x[1] + x[4] ≥ 0.0)
+  @constraint(model, 5 - 2 * x[1]^2 - x[2]^2 - x[3]^2 - 2 * x[1] + x[2] + x[4] ≥ 0.0)
 
   return MathOptNLSModel(model, [F1; F2; F3; F4], name = "hs43")
 end

--- a/test/nls_problems/mgh01.jl
+++ b/test/nls_problems/mgh01.jl
@@ -5,7 +5,7 @@ function mgh01()
   set_start_value(x[1], -1.2)
   set_start_value(x[2], 1.0)
 
-  @expression(model, F1, 1 - x[1])
+  @NLexpression(model, F1, 1 - x[1])
   @NLexpression(model, F2, 10 * (x[2] - x[1]^2))
 
   return MathOptNLSModel(model, [F1, F2], name = "mgh01")

--- a/test/nls_problems/mgh07.jl
+++ b/test/nls_problems/mgh07.jl
@@ -5,11 +5,12 @@ function mgh07()
   @variable(nls, x[i = 1:3], start = x0[i])
 
   θ_aux(t) = (t > 0 ? 0.0 : 0.5)
-  JuMP.register(nls, :θ_aux, 1, θ_aux, autodiff = true)
+
+  @operator(nls, θ, 1, θ_aux)
 
   @expression(nls, F1, x[3])
-  @NLexpression(nls, F2, 10 * (x[3] - 10 * (atan(x[2] / x[1]) / (2 * π) + θ_aux(x[1]))))
-  @NLexpression(nls, F3, 10 * (sqrt(x[1]^2 + x[2]^2) - 1.0))
+  @expression(nls, F2, 10 * (x[3] - 10 * (atan(x[2] / x[1]) / (2 * π) + θ(x[1]))))
+  @expression(nls, F3, 10 * (sqrt(x[1]^2 + x[2]^2) - 1.0))
 
   return MathOptNLSModel(nls, [F1, F2, F3], name = "mgh07")
 end

--- a/test/nls_problems/nlsnohesspb.jl
+++ b/test/nls_problems/nlsnohesspb.jl
@@ -7,9 +7,8 @@ function nlsnohesspb()
   x₀ = [1.0, 0.1, 0.2, -0.5, 1.0]
   @variable(nls, x[i = 1:n], start = x₀[i])
 
-  register(nls, :g, n, g, autodiff = true)
-
-  @NLexpression(nls, res[i in 1:n], g(x...))
+  @operator(nls, custom_g, n, g)
+  @expression(nls, res[i in 1:n], custom_g(x...))
 
   return MathOptNLSModel(nls, res, hessian = false, name = "nlsnohesspb")
 end

--- a/test/nls_problems/nlsqc.jl
+++ b/test/nls_problems/nlsqc.jl
@@ -7,7 +7,7 @@ function nlsqc()
   @constraint(nls, [x[2], x[2]^2 + x[2] * x[3] + 4.0] in MOI.Nonpositives(2))
   @constraint(nls, [x[3], x[3]^2 + x[3] * x[1] + 5.0] in MOI.Zeros(2))
 
-  @NLexpression(nls, F[i = 1:3], x[i]^2 - i^2)
+  @expression(nls, F[i = 1:3], x[i]^2 - i^2)
 
   return MathOptNLSModel(nls, F, name = "nlsqc")
 end

--- a/test/test_moi_nls_model.jl
+++ b/test/test_moi_nls_model.jl
@@ -31,12 +31,12 @@ println()
 println("Testing 2d cat array on NLS")
 model = Model()
 @variable(model, x[1:2])
-@expression(model, F[i = 1:2], x[i] - 1)
+@NLexpression(model, F[i = 1:2], x[i] - 1)
 @NLexpression(model, G[i = 1:2], x[i]^2 - 1)
 @NLexpression(model, H[i = 1:2, j = 1:2], x[i] * x[j] - 1)
 @test F isa Array{GenericAffExpr{Float64, VariableRef}}
-@test G isa Array{NonlinearExpression}
-@test H isa Array{NonlinearExpression}
+@test G isa Array{QuadExpr}
+@test H isa Array{QuadExpr}
 nls = MathOptNLSModel(model, [[F G]; H])
 @test all(residual(nls, ones(2)) .== 0.0)
 @test jac_residual(nls, ones(2))' * residual(nls, ones(2)) == [0.0; 0.0]
@@ -60,7 +60,7 @@ nls = MathOptNLSModel(model, F)
 # Nonlinear expressions
 model = Model()
 @variable(model, x[1:2])
-@NLexpression(model, F[i = -1:1, j = 1:2], x[j] - i)
+@expression(model, F[i = -1:1, j = 1:2], x[j] - i)
 @test F isa JuMP.Containers.DenseAxisArray
 nls = MathOptNLSModel(model, F)
 @test residual(nls, zeros(2)) == [1.0; 0.0; -1.0; 1.0; 0.0; -1.0]
@@ -80,7 +80,7 @@ nls = MathOptNLSModel(model, F)
 model = Model()
 @variable(model, x[1:2])
 D = Dict(1 => 2, 2 => 4)
-@NLexpression(model, F[i = 1:2, j = 1:D[i]], x[i] - j)
+@expression(model, F[i = 1:2, j = 1:D[i]], x[i] - j)
 @test F isa JuMP.Containers.SparseAxisArray
 nls = MathOptNLSModel(model, F)
 @test sort(residual(nls, [1.5; 2.5])) == [-1.5; -0.5; -0.5; 0.5; 0.5; 1.5]
@@ -105,11 +105,11 @@ nls = MathOptNLSModel(model, [F, G])
 model = Model()
 @variable(model, x[1:4])
 D = Dict(1 => 2, 2 => 4)
-@NLexpression(model, F[i = 1:2, j = 1:D[i]], x[i] - j)
-@NLexpression(model, G[i = -1:1, j = 3:4], x[j] - i)
+@expression(model, F[i = 1:2, j = 1:D[i]], x[i] - j)
+@expression(model, G[i = -1:1, j = 3:4], x[j] - i)
 @test F isa JuMP.Containers.SparseAxisArray
 @test G isa JuMP.Containers.DenseAxisArray
-@test [F, G] isa Array{<:AbstractArray{NonlinearExpression}}
+@test [F, G] isa Array{<:AbstractArray{AffExpr}}
 nls = MathOptNLSModel(model, [F, G])
 @test sort(residual(nls, [1.5; 2.5; 0.0; 0.0])) ==
       [-1.5; -1.0; -1.0; -0.5; -0.5; 0.0; 0.0; 0.5; 0.5; 1.0; 1.0; 1.5]


### PR DESCRIPTION
We have one remaining issue: the `MathOptNLSModel` depends on the legacy nonlinear interface to formulate quadratic residuals which [are not supported by default](https://github.com/JuliaSmoothOptimizers/NLPModelsJuMP.jl/blob/main/src/utils.jl#L793). 

We should add this support explicitly if we do not want to break NLPModelsJuMP. This would require some non-trivial changes in `MathOptNLSModel` though. 